### PR TITLE
Quick edit to fix the Sigwada's Star Card

### DIFF
--- a/FP2Lib/FP2Lib.cs
+++ b/FP2Lib/FP2Lib.cs
@@ -3,6 +3,7 @@ using BepInEx.Configuration;
 using BepInEx.Logging;
 using FP2Lib.Badge;
 using FP2Lib.BepIn;
+using FP2Lib.Item;
 using FP2Lib.NPC;
 using FP2Lib.Patches;
 using FP2Lib.Player;
@@ -112,6 +113,7 @@ namespace FP2Lib
             playerPatches.PatchAll(typeof(PatchMenuShop));
             playerPatches.PatchAll(typeof(PatchPlayerDialogZone));
             playerPatches.PatchAll(typeof(PatchZLBaseballFlyer));
+            playerPatches.PatchAll(typeof(PatchItemStarCard));
 
             //Vinyls
             Logger.LogDebug("Vinyl Patch Init");

--- a/FP2Lib/Item/PatchItemStarCard.cs
+++ b/FP2Lib/Item/PatchItemStarCard.cs
@@ -1,0 +1,24 @@
+﻿using FP2Lib.Player;
+using HarmonyLib;
+using System.Linq;
+
+namespace FP2Lib.Item
+{
+    internal class PatchItemStarCard
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(ItemStarCard), "Start", MethodType.Normal)]
+        static void PatchStart(ref FPCharacterID[] ___disableForCharacter)
+        {
+            // Only run this check if the Star Card is set to be disabled for at least one character.
+            if (___disableForCharacter.Length == 0)
+                return;
+
+            // Loop through each character. If they're registered, check if the original disabled array contains their event base. If so, add them to the list.
+            foreach (PlayableChara chara in PlayerHandler.PlayableChars.Values)
+                if (chara.registered)
+                    if (___disableForCharacter.Contains(chara.eventActivatorCharacter))
+                        ___disableForCharacter = ___disableForCharacter.AddToArray((FPCharacterID)chara.id);
+        }
+    }
+}


### PR DESCRIPTION
Custom characters that weren't using Carol's event activator were caught in a weird state where the Star Card she uses for it would appear, but so would the character base's cutscene trigger.

If the player was fast enough, they could collect the card before the cutscene, leading to a functional Results Screen overlapping the Cory fight.
![bafkreidk4kqunhszedtpsmpr5ljkofl4s34syoghokupvagm3yliimnogm](https://github.com/user-attachments/assets/5d742653-9247-4903-b030-3d1923e34de6)

This commit checks the `disableForCharacter` array when creating the card and, if it has at least one entry, will go through the registered characters and add them to the array if their event activator matches the ID of a character already present in it.

A more sensible way to do this might be to add a thing to the playable character class to specify scenes to remove a Star Card from? Although some would need some, probably messy, hardcoding shenanigans (like with the Sigwada, which has two).