### PR TITLE
Bakunawa Fusion Assist Character Bugfix

### DIFF
--- a/FP2Lib/FP2Lib.cs
+++ b/FP2Lib/FP2Lib.cs
@@ -15,7 +15,7 @@ using HarmonyLib;
 
 namespace FP2Lib
 {
-    [BepInPlugin("000.kuborro.libraries.fp2.fp2lib", "FP2Lib", "0.3.0.1")]
+    [BepInPlugin("000.kuborro.libraries.fp2.fp2lib", "FP2Lib", "0.3.0.2")]
     [BepInProcess("FP2.exe")]
     public class FP2Lib : BaseUnityPlugin
     {

--- a/FP2Lib/Player/PlayerPatches/PatchBakunawaFusion.cs
+++ b/FP2Lib/Player/PlayerPatches/PatchBakunawaFusion.cs
@@ -8,7 +8,7 @@ namespace FP2Lib.Player.PlayerPatches
         [HarmonyPatch(typeof(Bakunawa), "Activate", MethodType.Normal)]
         static void PatchBakunawaActivate(Bakunawa __instance)
         {
-            if (FPSaveManager.character <= (FPCharacterID)5)
+            if (FPSaveManager.character >= (FPCharacterID)5)
             {
                 //Everyone is here to help!
                 __instance.assistRoster.Add(Bakunawa.Assist.Milla);

--- a/FP2Lib/Player/PlayerPatches/PatchFPBossHud.cs
+++ b/FP2Lib/Player/PlayerPatches/PatchFPBossHud.cs
@@ -10,7 +10,7 @@ namespace FP2Lib.Player.PlayerPatches
         static void PatchFPBossHudStart(FPBossHud __instance)
         {
             //We fightin' everyone, so move the health bars
-            if (FPSaveManager.character <= (FPCharacterID)5)
+            if (FPSaveManager.character >= (FPCharacterID)5)
             {
                 switch (__instance.name)
                 {


### PR DESCRIPTION
While attempting (and failing miserably) to make it so that custom characters could have a sprite for being impaled in Weapon's Core, I noticed that the check for adding the other characters to the assist array for Bakunawa Fusion was checking if the ID was LESS than or equal to 5, resulting in a copy of the player character appearing if they were a base game one.

In theory, this also would have prevented any assists at all if a second modded character was used, as their ID would be at least 6.

It also appears that this same error was made in the Boss HUD for the Hero Battle Royale Challenge, so I've swapped that as well.

(Not sure if I should bump the version number in PRs or not, oh well).