### PR TITLE
Credits Fixes

### DIFF
--- a/FP2Lib/FP2Lib.cs
+++ b/FP2Lib/FP2Lib.cs
@@ -114,6 +114,7 @@ namespace FP2Lib
             playerPatches.PatchAll(typeof(PatchPlayerDialogZone));
             playerPatches.PatchAll(typeof(PatchZLBaseballFlyer));
             playerPatches.PatchAll(typeof(PatchItemStarCard));
+            playerPatches.PatchAll(typeof(PatchPlayerBossMerga));
 
             //Vinyls
             Logger.LogDebug("Vinyl Patch Init");

--- a/FP2Lib/Player/PlayerPatches/PatchFPStage.cs
+++ b/FP2Lib/Player/PlayerPatches/PatchFPStage.cs
@@ -1,4 +1,6 @@
 ﻿using HarmonyLib;
+using System.Linq;
+using UnityEngine.SceneManagement;
 
 namespace FP2Lib.Player.PlayerPatches
 {
@@ -19,6 +21,31 @@ namespace FP2Lib.Player.PlayerPatches
                 if (chara.registered)
                 {
                     ___playerList[chara.id] = chara.prefab.GetComponent<FPPlayer>();
+                }
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(FPStage), "Start", MethodType.Normal)]
+        static void WeaponsCoreEnding(ref FPResultsMenuSceneChange[] ___adventureCutscene)
+        {
+            // Only apply this edit if the player is in Weapon's Core.
+            if (SceneManager.GetActiveScene().name == "Bakunawa5")
+            {
+                // Loop through each custom player character.
+                for (int i = 0; i < PlayerHandler.PlayableChars.Values.Count; i++)
+                {
+                    // Get the player value at this index.
+                    var entry = PlayerHandler.PlayableChars.ElementAt(i).Value;
+
+                    // Add an entry for this character to the Adventure Cutscene array to load the ending for them.
+                    ___adventureCutscene = ___adventureCutscene.AddToArray(new()
+                    {
+                        character = (FPCharacterID)entry.id,
+                        scene = "Cutscene_Ending2",
+                        storyFlag = 46,
+                        storyFlagValue = 1
+                    });
                 }
             }
         }

--- a/FP2Lib/Player/PlayerPatches/PatchMenuCredits.cs
+++ b/FP2Lib/Player/PlayerPatches/PatchMenuCredits.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using System.Linq;
 using UnityEngine;
 
 namespace FP2Lib.Player.PlayerPatches
@@ -10,15 +9,20 @@ namespace FP2Lib.Player.PlayerPatches
         [HarmonyPatch(typeof(MenuCredits), "Start", MethodType.Normal)]
         static void PatchMenuCreditsStart(ref AudioClip[] ___bgmCredits, ref Sprite[] ___characterSprites)
         {
-            // Loop through each custom player character.
-            for (int i = 0; i < PlayerHandler.PlayableChars.Values.Count; i++)
+            //Load per-character ending art
+            for (int i = 5; i <= PlayerHandler.highestID; i++)
             {
-                // Get the player value at this index.
-                var entry = PlayerHandler.PlayableChars.ElementAt(i).Value;
+                ___bgmCredits = ___bgmCredits.AddToArray(null);
+                ___characterSprites = ___characterSprites.AddToArray(null);
+            }
 
-                // Add their ending track and key art to the approriate arrays.
-                ___bgmCredits = ___bgmCredits.AddToArray(entry.endingTrack);
-                ___characterSprites = ___characterSprites.AddToArray(entry.endingKeyArtSprite);
+            foreach (PlayableChara chara in PlayerHandler.PlayableChars.Values)
+            {
+                if (chara.registered)
+                {
+                    ___bgmCredits[chara.id] = chara.endingTrack;
+                    ___characterSprites[chara.id] = chara.endingKeyArtSprite;
+                }
             }
         }
     }

--- a/FP2Lib/Player/PlayerPatches/PatchMenuCredits.cs
+++ b/FP2Lib/Player/PlayerPatches/PatchMenuCredits.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using System.Linq;
 using UnityEngine;
 
 namespace FP2Lib.Player.PlayerPatches
@@ -9,20 +10,15 @@ namespace FP2Lib.Player.PlayerPatches
         [HarmonyPatch(typeof(MenuCredits), "Start", MethodType.Normal)]
         static void PatchMenuCreditsStart(ref AudioClip[] ___bgmCredits, ref Sprite[] ___characterSprites)
         {
-            //Load per-character ending art
-            for (int i = 5; i < PlayerHandler.highestID; i++)
+            // Loop through each custom player character.
+            for (int i = 0; i < PlayerHandler.PlayableChars.Values.Count; i++)
             {
-                ___bgmCredits = ___bgmCredits.AddToArray(null);
-                ___characterSprites = ___characterSprites.AddToArray(null);
-            }
+                // Get the player value at this index.
+                var entry = PlayerHandler.PlayableChars.ElementAt(i).Value;
 
-            foreach (PlayableChara chara in PlayerHandler.PlayableChars.Values)
-            {
-                if (chara.registered)
-                {
-                    ___bgmCredits[chara.id] = chara.endingTrack;
-                    ___characterSprites[chara.id] = chara.endingKeyArtSprite;
-                }
+                // Add their ending track and key art to the approriate arrays.
+                ___bgmCredits = ___bgmCredits.AddToArray(entry.endingTrack);
+                ___characterSprites = ___characterSprites.AddToArray(entry.endingKeyArtSprite);
             }
         }
     }

--- a/FP2Lib/Player/PlayerPatches/PatchPlayerBossMerga.cs
+++ b/FP2Lib/Player/PlayerPatches/PatchPlayerBossMerga.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using System.Linq;
+
+namespace FP2Lib.Player.PlayerPatches
+{
+    internal class PatchPlayerBossMerga
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(PlayerBossMerga), "Start", MethodType.Normal)]
+        static void MergaEnding(ref FPResultsMenuSceneChange[] ___adventureCutscene)
+        {
+            // Loop through each custom player character.
+            for (int i = 0; i < PlayerHandler.PlayableChars.Values.Count; i++)
+            {
+                // Get the player value at this index.
+                var entry = PlayerHandler.PlayableChars.ElementAt(i).Value;
+
+                // Add an entry for this character to the Adventure Cutscene array to load the ending for them.
+                ___adventureCutscene = ___adventureCutscene.AddToArray(new()
+                {
+                    character = (FPCharacterID)entry.id,
+                    scene = "Cutscene_Ending2",
+                    storyFlag = 46,
+                    storyFlagValue = 1
+                });
+            }
+        }
+    }
+}

--- a/FP2Lib/Player/PlayerPatches/PatchPlayerBossMerga.cs
+++ b/FP2Lib/Player/PlayerPatches/PatchPlayerBossMerga.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using System.Linq;
+using UnityEngine.SceneManagement;
 
 namespace FP2Lib.Player.PlayerPatches
 {
@@ -9,20 +10,24 @@ namespace FP2Lib.Player.PlayerPatches
         [HarmonyPatch(typeof(PlayerBossMerga), "Start", MethodType.Normal)]
         static void MergaEnding(ref FPResultsMenuSceneChange[] ___adventureCutscene)
         {
-            // Loop through each custom player character.
-            for (int i = 0; i < PlayerHandler.PlayableChars.Values.Count; i++)
+            // Only apply this edit if the player is in Merga's actual boss fight.
+            if (SceneManager.GetActiveScene().name == "Bakunawa4Boss")
             {
-                // Get the player value at this index.
-                var entry = PlayerHandler.PlayableChars.ElementAt(i).Value;
-
-                // Add an entry for this character to the Adventure Cutscene array to load the ending for them.
-                ___adventureCutscene = ___adventureCutscene.AddToArray(new()
+                // Loop through each custom player character.
+                for (int i = 0; i < PlayerHandler.PlayableChars.Values.Count; i++)
                 {
-                    character = (FPCharacterID)entry.id,
-                    scene = "Cutscene_Ending2",
-                    storyFlag = 46,
-                    storyFlagValue = 1
-                });
+                    // Get the player value at this index.
+                    var entry = PlayerHandler.PlayableChars.ElementAt(i).Value;
+
+                    // Add an entry for this character to the Adventure Cutscene array to load the ending for them.
+                    ___adventureCutscene = ___adventureCutscene.AddToArray(new()
+                    {
+                        character = (FPCharacterID)entry.id,
+                        scene = "Cutscene_Ending2",
+                        storyFlag = 46,
+                        storyFlagValue = 1
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
They didn't start for custom characters thanks to how Merga and Weapon's Core call for the ending and didn't even work at all (throwing a null reference exception regarding the arrays). They seem to function now (at least with Sonic, should probably test more using Spade and other test characters).

I'm not checking the character is registered when adding them to the arrays, but I don't think that's a problem? Tried with and without Spade installed alongside Sonic and it seemed to work regardless?